### PR TITLE
Improving the usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require runtime/roadrunner-symfony-nyholm
 Define the environment variable `APP_RUNTIME` for your application.
 
 ```
-APP_RUNTIME=Runtime\RoadRunnerSymfonyNyholm\Runtime
+APP_RUNTIME=Runtime\\RoadRunnerSymfonyNyholm\\Runtime
 ```
 
 


### PR DESCRIPTION
If someone was blindly copy/pasting the current usage example like me into the .env environment file he/she will get the following error when starting the RoadRunner:

```
 ERROR   container/poller.go:16  vertex got an error     {"vertex id": "http.Plugin", "error": "http_plugin_serve: WorkerAllocate:\n\tserver_plugin_new_worker_pool:\n\tstatic_pool_initialize:\n\tallocate workers:\n\tfactory_spawn_worker_with_timeout: fetch_pid: CRC mismatch; signal: killed; process_wait: signal: killed"}
github.com/spiral/endure/pkg/container.(*Endure).poll.func1
        github.com/spiral/endure@v1.0.2/pkg/container/poller.go:16
error occurred: http_plugin_serve: WorkerAllocate:
        server_plugin_new_worker_pool:
        static_pool_initialize:
        allocate workers:
        factory_spawn_worker_with_timeout: fetch_pid: CRC mismatch; signal: killed; process_wait: signal: killed, plugin: http.Plugin
handle_serve_command: http_plugin_serve: WorkerAllocate:
        server_plugin_new_worker_pool:
        static_pool_initialize:
        allocate workers:
        factory_spawn_worker_with_timeout: fetch_pid: CRC mismatch; signal: killed; process_wait: signal: killed; fsm_recognizer: can't transition from state: Stopped by event Stop
```

It took me quite some time to figure out what was going on due to the above error which pointed me in the wrong direction.