### PR TITLE
Add information about Roadrunner server env config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ composer require runtime/roadrunner-symfony-nyholm
 Define the environment variable `APP_RUNTIME` for your application.
 
 ```
+// .env
 APP_RUNTIME=Runtime\RoadRunnerSymfonyNyholm\Runtime
 ```
 
+```
+// .rr.yaml
+server:
+    ...
+    env:
+        APP_RUNTIME: Runtime\RoadRunnerSymfonyNyholm\Runtime
+```
 
 ```php
 // public/index.php
@@ -31,4 +39,3 @@ return function (array $context) {
 };
 
 ```
-


### PR DESCRIPTION
I did not know that I have to provide `env` to the `.rr.yaml` config file and as a newbie, I put it only to the `.env` file. These systems work differently than Symfony I had to spend a lot of time to find this information.